### PR TITLE
Bug fix/DTS-47410 broken connection notification for Processor tools

### DIFF
--- a/argocd/src/main/resources/application.properties
+++ b/argocd/src/main/resources/application.properties
@@ -51,3 +51,15 @@ togglz.console.secured=false
 #Spring boot actuator properties
 management.endpoints.web.exposure.include=health
 management.endpoint.health.show-details=never
+
+
+broken-connection.maximum-email-notification-count=${MAXIMUMEMAILNOTIFICATIONCOUNT:3}
+broken-connection.email-notification-frequency=${EMAILNOTIFICATIONFREQUENCY:5}
+broken-connection.email-notification-subject=Action Required: Restore Your {{Tool_Name}} Connection
+broken-connection.fix-url=/#/dashboard/Config/ConfigSettings?tab=1
+broken-connection.help-url=https://publicissapient.atlassian.net/servicedesk/customer/portal/7/group/38/create/101
+broken-connection.kafka-mail-topic=mail-topic
+broken-connection.ui-host=localhost,127.0.0.1,ui,customapi
+broken-connection.notification-switch=true
+broken-connection.mail-without-kafka=true
+broken-connection.mail-template.Broken_Connection=Broken_Connection_Notification_Template

--- a/argocd/src/main/resources/templates/Broken_Connection_Notification_Template.html
+++ b/argocd/src/main/resources/templates/Broken_Connection_Notification_Template.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Broken Connection Alert</title>
+    <link href="http://fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css" />
+</head>
+
+<body style="font-family: 'Roboto', sans-serif; font-size: 16px; line-height: 24px; background-color: #f0f0f0; margin: 0;">
+<table cellpadding="0" cellspacing="0" style="width: 800px; margin: 20px auto; background-color: #ffffff;">
+    <tbody>
+    <tr>
+        <td style="padding: 30px; text-align: center;">
+            <div style="font-size: 42px;">
+                kn<span style="color: #FE414D;">o</span>w<span style="font-weight: 900;">HOW</span>
+            </div>
+            <hr style="border-top: 1px solid #0099ff;" />
+        </td>
+    </tr>
+    <tr>
+        <td style="padding: 25px;">
+            <p>Hi <strong th:text="${User_Name}"></strong>,</p>
+
+            <p>
+                We’ve detected that your <strong th:text="${Tool_Name}"></strong> connection is currently
+                <span style="color: #FE414D;">broken</span> — this is usually due to an expired token or authentication issue.
+                As a result, data fetching and syncing might be disrupted, and in some cases, historical data could be lost.
+            </p>
+
+            <p>
+                Please update your credentials promptly to ensure smooth data flow and avoid any potential data loss.
+            </p>
+
+            <div style="margin: 20px 0;">
+                <a th:href="${Fix_Url}" style="background-color: #0099ff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px;">
+                    Fix your connection now
+                </a>
+            </div>
+
+            <p>
+                Need help? Reach out to us anytime at
+                <a th:href="${Help_Url}">knowHOW Request</a>.
+            </p>
+
+            <p style="margin-top: 40px;">Thanks,<br/>The KnowHow Team</p>
+        </td>
+    </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/azure-boards/src/main/resources/application.properties
+++ b/azure-boards/src/main/resources/application.properties
@@ -97,3 +97,15 @@ togglz.console.secured=false
 #Spring boot actuator properties
 management.endpoints.web.exposure.include=health
 management.endpoint.health.show-details=never
+
+
+broken-connection.maximum-email-notification-count=${MAXIMUMEMAILNOTIFICATIONCOUNT:3}
+broken-connection.email-notification-frequency=${EMAILNOTIFICATIONFREQUENCY:5}
+broken-connection.email-notification-subject=Action Required: Restore Your {{Tool_Name}} Connection
+broken-connection.fix-url=/#/dashboard/Config/ConfigSettings?tab=1
+broken-connection.help-url=https://publicissapient.atlassian.net/servicedesk/customer/portal/7/group/38/create/101
+broken-connection.kafka-mail-topic=mail-topic
+broken-connection.ui-host=localhost,127.0.0.1,ui,customapi
+broken-connection.notification-switch=true
+broken-connection.mail-without-kafka=true
+broken-connection.mail-template.Broken_Connection=Broken_Connection_Notification_Template

--- a/azure-boards/src/main/resources/templates/Broken_Connection_Notification_Template.html
+++ b/azure-boards/src/main/resources/templates/Broken_Connection_Notification_Template.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Broken Connection Alert</title>
+    <link href="http://fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css" />
+</head>
+
+<body style="font-family: 'Roboto', sans-serif; font-size: 16px; line-height: 24px; background-color: #f0f0f0; margin: 0;">
+<table cellpadding="0" cellspacing="0" style="width: 800px; margin: 20px auto; background-color: #ffffff;">
+    <tbody>
+    <tr>
+        <td style="padding: 30px; text-align: center;">
+            <div style="font-size: 42px;">
+                kn<span style="color: #FE414D;">o</span>w<span style="font-weight: 900;">HOW</span>
+            </div>
+            <hr style="border-top: 1px solid #0099ff;" />
+        </td>
+    </tr>
+    <tr>
+        <td style="padding: 25px;">
+            <p>Hi <strong th:text="${User_Name}"></strong>,</p>
+
+            <p>
+                We’ve detected that your <strong th:text="${Tool_Name}"></strong> connection is currently
+                <span style="color: #FE414D;">broken</span> — this is usually due to an expired token or authentication issue.
+                As a result, data fetching and syncing might be disrupted, and in some cases, historical data could be lost.
+            </p>
+
+            <p>
+                Please update your credentials promptly to ensure smooth data flow and avoid any potential data loss.
+            </p>
+
+            <div style="margin: 20px 0;">
+                <a th:href="${Fix_Url}" style="background-color: #0099ff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px;">
+                    Fix your connection now
+                </a>
+            </div>
+
+            <p>
+                Need help? Reach out to us anytime at
+                <a th:href="${Help_Url}">knowHOW Request</a>.
+            </p>
+
+            <p style="margin-top: 40px;">Thanks,<br/>The KnowHow Team</p>
+        </td>
+    </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/azure-pipeline/src/main/resources/application.properties
+++ b/azure-pipeline/src/main/resources/application.properties
@@ -54,3 +54,14 @@ togglz.console.secured=false
 #Spring boot actuator properties
 management.endpoints.web.exposure.include=health
 management.endpoint.health.show-details=never
+
+broken-connection.maximum-email-notification-count=${MAXIMUMEMAILNOTIFICATIONCOUNT:3}
+broken-connection.email-notification-frequency=${EMAILNOTIFICATIONFREQUENCY:5}
+broken-connection.email-notification-subject=Action Required: Restore Your {{Tool_Name}} Connection
+broken-connection.fix-url=/#/dashboard/Config/ConfigSettings?tab=1
+broken-connection.help-url=https://publicissapient.atlassian.net/servicedesk/customer/portal/7/group/38/create/101
+broken-connection.kafka-mail-topic=mail-topic
+broken-connection.ui-host=localhost,127.0.0.1,ui,customapi
+broken-connection.notification-switch=true
+broken-connection.mail-without-kafka=true
+broken-connection.mail-template.Broken_Connection=Broken_Connection_Notification_Template

--- a/azure-pipeline/src/main/resources/templates/Broken_Connection_Notification_Template.html
+++ b/azure-pipeline/src/main/resources/templates/Broken_Connection_Notification_Template.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Broken Connection Alert</title>
+    <link href="http://fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css" />
+</head>
+
+<body style="font-family: 'Roboto', sans-serif; font-size: 16px; line-height: 24px; background-color: #f0f0f0; margin: 0;">
+<table cellpadding="0" cellspacing="0" style="width: 800px; margin: 20px auto; background-color: #ffffff;">
+    <tbody>
+    <tr>
+        <td style="padding: 30px; text-align: center;">
+            <div style="font-size: 42px;">
+                kn<span style="color: #FE414D;">o</span>w<span style="font-weight: 900;">HOW</span>
+            </div>
+            <hr style="border-top: 1px solid #0099ff;" />
+        </td>
+    </tr>
+    <tr>
+        <td style="padding: 25px;">
+            <p>Hi <strong th:text="${User_Name}"></strong>,</p>
+
+            <p>
+                We’ve detected that your <strong th:text="${Tool_Name}"></strong> connection is currently
+                <span style="color: #FE414D;">broken</span> — this is usually due to an expired token or authentication issue.
+                As a result, data fetching and syncing might be disrupted, and in some cases, historical data could be lost.
+            </p>
+
+            <p>
+                Please update your credentials promptly to ensure smooth data flow and avoid any potential data loss.
+            </p>
+
+            <div style="margin: 20px 0;">
+                <a th:href="${Fix_Url}" style="background-color: #0099ff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px;">
+                    Fix your connection now
+                </a>
+            </div>
+
+            <p>
+                Need help? Reach out to us anytime at
+                <a th:href="${Help_Url}">knowHOW Request</a>.
+            </p>
+
+            <p style="margin-top: 40px;">Thanks,<br/>The KnowHow Team</p>
+        </td>
+    </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/azure-repo/src/main/resources/application.properties
+++ b/azure-repo/src/main/resources/application.properties
@@ -58,3 +58,15 @@ togglz.console.secured=false
 #Spring boot actuator properties
 management.endpoints.web.exposure.include=health
 management.endpoint.health.show-details=never
+
+
+broken-connection.maximum-email-notification-count=${MAXIMUMEMAILNOTIFICATIONCOUNT:3}
+broken-connection.email-notification-frequency=${EMAILNOTIFICATIONFREQUENCY:5}
+broken-connection.email-notification-subject=Action Required: Restore Your {{Tool_Name}} Connection
+broken-connection.fix-url=/#/dashboard/Config/ConfigSettings?tab=1
+broken-connection.help-url=https://publicissapient.atlassian.net/servicedesk/customer/portal/7/group/38/create/101
+broken-connection.kafka-mail-topic=mail-topic
+broken-connection.ui-host=localhost,127.0.0.1,ui,customapi
+broken-connection.notification-switch=true
+broken-connection.mail-without-kafka=true
+broken-connection.mail-template.Broken_Connection=Broken_Connection_Notification_Template

--- a/azure-repo/src/main/resources/templates/Broken_Connection_Notification_Template.html
+++ b/azure-repo/src/main/resources/templates/Broken_Connection_Notification_Template.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Broken Connection Alert</title>
+    <link href="http://fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css" />
+</head>
+
+<body style="font-family: 'Roboto', sans-serif; font-size: 16px; line-height: 24px; background-color: #f0f0f0; margin: 0;">
+<table cellpadding="0" cellspacing="0" style="width: 800px; margin: 20px auto; background-color: #ffffff;">
+    <tbody>
+    <tr>
+        <td style="padding: 30px; text-align: center;">
+            <div style="font-size: 42px;">
+                kn<span style="color: #FE414D;">o</span>w<span style="font-weight: 900;">HOW</span>
+            </div>
+            <hr style="border-top: 1px solid #0099ff;" />
+        </td>
+    </tr>
+    <tr>
+        <td style="padding: 25px;">
+            <p>Hi <strong th:text="${User_Name}"></strong>,</p>
+
+            <p>
+                We’ve detected that your <strong th:text="${Tool_Name}"></strong> connection is currently
+                <span style="color: #FE414D;">broken</span> — this is usually due to an expired token or authentication issue.
+                As a result, data fetching and syncing might be disrupted, and in some cases, historical data could be lost.
+            </p>
+
+            <p>
+                Please update your credentials promptly to ensure smooth data flow and avoid any potential data loss.
+            </p>
+
+            <div style="margin: 20px 0;">
+                <a th:href="${Fix_Url}" style="background-color: #0099ff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px;">
+                    Fix your connection now
+                </a>
+            </div>
+
+            <p>
+                Need help? Reach out to us anytime at
+                <a th:href="${Help_Url}">knowHOW Request</a>.
+            </p>
+
+            <p style="margin-top: 40px;">Thanks,<br/>The KnowHow Team</p>
+        </td>
+    </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/bamboo/src/main/resources/application.properties
+++ b/bamboo/src/main/resources/application.properties
@@ -53,3 +53,14 @@ togglz.console.secured=false
 #Spring boot actuator properties
 management.endpoints.web.exposure.include=health
 management.endpoint.health.show-details=never
+
+broken-connection.maximum-email-notification-count=${MAXIMUMEMAILNOTIFICATIONCOUNT:3}
+broken-connection.email-notification-frequency=${EMAILNOTIFICATIONFREQUENCY:5}
+broken-connection.email-notification-subject=Action Required: Restore Your {{Tool_Name}} Connection
+broken-connection.fix-url=/#/dashboard/Config/ConfigSettings?tab=1
+broken-connection.help-url=https://publicissapient.atlassian.net/servicedesk/customer/portal/7/group/38/create/101
+broken-connection.kafka-mail-topic=mail-topic
+broken-connection.ui-host=localhost,127.0.0.1,ui,customapi
+broken-connection.notification-switch=true
+broken-connection.mail-without-kafka=true
+broken-connection.mail-template.Broken_Connection=Broken_Connection_Notification_Template

--- a/bamboo/src/main/resources/templates/Broken_Connection_Notification_Template.html
+++ b/bamboo/src/main/resources/templates/Broken_Connection_Notification_Template.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Broken Connection Alert</title>
+    <link href="http://fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css" />
+</head>
+
+<body style="font-family: 'Roboto', sans-serif; font-size: 16px; line-height: 24px; background-color: #f0f0f0; margin: 0;">
+<table cellpadding="0" cellspacing="0" style="width: 800px; margin: 20px auto; background-color: #ffffff;">
+    <tbody>
+    <tr>
+        <td style="padding: 30px; text-align: center;">
+            <div style="font-size: 42px;">
+                kn<span style="color: #FE414D;">o</span>w<span style="font-weight: 900;">HOW</span>
+            </div>
+            <hr style="border-top: 1px solid #0099ff;" />
+        </td>
+    </tr>
+    <tr>
+        <td style="padding: 25px;">
+            <p>Hi <strong th:text="${User_Name}"></strong>,</p>
+
+            <p>
+                We’ve detected that your <strong th:text="${Tool_Name}"></strong> connection is currently
+                <span style="color: #FE414D;">broken</span> — this is usually due to an expired token or authentication issue.
+                As a result, data fetching and syncing might be disrupted, and in some cases, historical data could be lost.
+            </p>
+
+            <p>
+                Please update your credentials promptly to ensure smooth data flow and avoid any potential data loss.
+            </p>
+
+            <div style="margin: 20px 0;">
+                <a th:href="${Fix_Url}" style="background-color: #0099ff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px;">
+                    Fix your connection now
+                </a>
+            </div>
+
+            <p>
+                Need help? Reach out to us anytime at
+                <a th:href="${Help_Url}">knowHOW Request</a>.
+            </p>
+
+            <p style="margin-top: 40px;">Thanks,<br/>The KnowHow Team</p>
+        </td>
+    </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/bitbucket/src/main/resources/application.properties
+++ b/bitbucket/src/main/resources/application.properties
@@ -63,3 +63,15 @@ togglz.console.secured=false
 #Spring boot actuator properties
 management.endpoints.web.exposure.include=health
 management.endpoint.health.show-details=never
+
+
+broken-connection.maximum-email-notification-count=${MAXIMUMEMAILNOTIFICATIONCOUNT:3}
+broken-connection.email-notification-frequency=${EMAILNOTIFICATIONFREQUENCY:5}
+broken-connection.email-notification-subject=Action Required: Restore Your {{Tool_Name}} Connection
+broken-connection.fix-url=/#/dashboard/Config/ConfigSettings?tab=1
+broken-connection.help-url=https://publicissapient.atlassian.net/servicedesk/customer/portal/7/group/38/create/101
+broken-connection.kafka-mail-topic=mail-topic
+broken-connection.ui-host=localhost,127.0.0.1,ui,customapi
+broken-connection.notification-switch=true
+broken-connection.mail-without-kafka=true
+broken-connection.mail-template.Broken_Connection=Broken_Connection_Notification_Template

--- a/bitbucket/src/main/resources/templates/Broken_Connection_Notification_Template.html
+++ b/bitbucket/src/main/resources/templates/Broken_Connection_Notification_Template.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Broken Connection Alert</title>
+    <link href="http://fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css" />
+</head>
+
+<body style="font-family: 'Roboto', sans-serif; font-size: 16px; line-height: 24px; background-color: #f0f0f0; margin: 0;">
+<table cellpadding="0" cellspacing="0" style="width: 800px; margin: 20px auto; background-color: #ffffff;">
+    <tbody>
+    <tr>
+        <td style="padding: 30px; text-align: center;">
+            <div style="font-size: 42px;">
+                kn<span style="color: #FE414D;">o</span>w<span style="font-weight: 900;">HOW</span>
+            </div>
+            <hr style="border-top: 1px solid #0099ff;" />
+        </td>
+    </tr>
+    <tr>
+        <td style="padding: 25px;">
+            <p>Hi <strong th:text="${User_Name}"></strong>,</p>
+
+            <p>
+                We’ve detected that your <strong th:text="${Tool_Name}"></strong> connection is currently
+                <span style="color: #FE414D;">broken</span> — this is usually due to an expired token or authentication issue.
+                As a result, data fetching and syncing might be disrupted, and in some cases, historical data could be lost.
+            </p>
+
+            <p>
+                Please update your credentials promptly to ensure smooth data flow and avoid any potential data loss.
+            </p>
+
+            <div style="margin: 20px 0;">
+                <a th:href="${Fix_Url}" style="background-color: #0099ff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px;">
+                    Fix your connection now
+                </a>
+            </div>
+
+            <p>
+                Need help? Reach out to us anytime at
+                <a th:href="${Help_Url}">knowHOW Request</a>.
+            </p>
+
+            <p style="margin-top: 40px;">Thanks,<br/>The KnowHow Team</p>
+        </td>
+    </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/github-action/src/main/resources/application.properties
+++ b/github-action/src/main/resources/application.properties
@@ -58,3 +58,16 @@ togglz.console.secured=false
 #Spring boot actuator properties
 management.endpoints.web.exposure.include=health
 management.endpoint.health.show-details=never
+
+
+
+broken-connection.maximum-email-notification-count=${MAXIMUMEMAILNOTIFICATIONCOUNT:3}
+broken-connection.email-notification-frequency=${EMAILNOTIFICATIONFREQUENCY:5}
+broken-connection.email-notification-subject=Action Required: Restore Your {{Tool_Name}} Connection
+broken-connection.fix-url=/#/dashboard/Config/ConfigSettings?tab=1
+broken-connection.help-url=https://publicissapient.atlassian.net/servicedesk/customer/portal/7/group/38/create/101
+broken-connection.kafka-mail-topic=mail-topic
+broken-connection.ui-host=localhost,127.0.0.1,ui,customapi
+broken-connection.notification-switch=true
+broken-connection.mail-without-kafka=true
+broken-connection.mail-template.Broken_Connection=Broken_Connection_Notification_Template

--- a/github-action/src/main/resources/templates/Broken_Connection_Notification_Template.html
+++ b/github-action/src/main/resources/templates/Broken_Connection_Notification_Template.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Broken Connection Alert</title>
+    <link href="http://fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css" />
+</head>
+
+<body style="font-family: 'Roboto', sans-serif; font-size: 16px; line-height: 24px; background-color: #f0f0f0; margin: 0;">
+<table cellpadding="0" cellspacing="0" style="width: 800px; margin: 20px auto; background-color: #ffffff;">
+    <tbody>
+    <tr>
+        <td style="padding: 30px; text-align: center;">
+            <div style="font-size: 42px;">
+                kn<span style="color: #FE414D;">o</span>w<span style="font-weight: 900;">HOW</span>
+            </div>
+            <hr style="border-top: 1px solid #0099ff;" />
+        </td>
+    </tr>
+    <tr>
+        <td style="padding: 25px;">
+            <p>Hi <strong th:text="${User_Name}"></strong>,</p>
+
+            <p>
+                We’ve detected that your <strong th:text="${Tool_Name}"></strong> connection is currently
+                <span style="color: #FE414D;">broken</span> — this is usually due to an expired token or authentication issue.
+                As a result, data fetching and syncing might be disrupted, and in some cases, historical data could be lost.
+            </p>
+
+            <p>
+                Please update your credentials promptly to ensure smooth data flow and avoid any potential data loss.
+            </p>
+
+            <div style="margin: 20px 0;">
+                <a th:href="${Fix_Url}" style="background-color: #0099ff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px;">
+                    Fix your connection now
+                </a>
+            </div>
+
+            <p>
+                Need help? Reach out to us anytime at
+                <a th:href="${Help_Url}">knowHOW Request</a>.
+            </p>
+
+            <p style="margin-top: 40px;">Thanks,<br/>The KnowHow Team</p>
+        </td>
+    </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/github/src/main/resources/application.properties
+++ b/github/src/main/resources/application.properties
@@ -58,3 +58,14 @@ togglz.console.secured=false
 #Spring boot actuator properties
 management.endpoints.web.exposure.include=health
 management.endpoint.health.show-details=never
+
+broken-connection.maximum-email-notification-count=${MAXIMUMEMAILNOTIFICATIONCOUNT:3}
+broken-connection.email-notification-frequency=${EMAILNOTIFICATIONFREQUENCY:5}
+broken-connection.email-notification-subject=Action Required: Restore Your {{Tool_Name}} Connection
+broken-connection.fix-url=/#/dashboard/Config/ConfigSettings?tab=1
+broken-connection.help-url=https://publicissapient.atlassian.net/servicedesk/customer/portal/7/group/38/create/101
+broken-connection.kafka-mail-topic=mail-topic
+broken-connection.ui-host=localhost,127.0.0.1,ui,customapi
+broken-connection.notification-switch=true
+broken-connection.mail-without-kafka=true
+broken-connection.mail-template.Broken_Connection=Broken_Connection_Notification_Template

--- a/github/src/main/resources/templates/Broken_Connection_Notification_Template.html
+++ b/github/src/main/resources/templates/Broken_Connection_Notification_Template.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Broken Connection Alert</title>
+    <link href="http://fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css" />
+</head>
+
+<body style="font-family: 'Roboto', sans-serif; font-size: 16px; line-height: 24px; background-color: #f0f0f0; margin: 0;">
+<table cellpadding="0" cellspacing="0" style="width: 800px; margin: 20px auto; background-color: #ffffff;">
+    <tbody>
+    <tr>
+        <td style="padding: 30px; text-align: center;">
+            <div style="font-size: 42px;">
+                kn<span style="color: #FE414D;">o</span>w<span style="font-weight: 900;">HOW</span>
+            </div>
+            <hr style="border-top: 1px solid #0099ff;" />
+        </td>
+    </tr>
+    <tr>
+        <td style="padding: 25px;">
+            <p>Hi <strong th:text="${User_Name}"></strong>,</p>
+
+            <p>
+                We’ve detected that your <strong th:text="${Tool_Name}"></strong> connection is currently
+                <span style="color: #FE414D;">broken</span> — this is usually due to an expired token or authentication issue.
+                As a result, data fetching and syncing might be disrupted, and in some cases, historical data could be lost.
+            </p>
+
+            <p>
+                Please update your credentials promptly to ensure smooth data flow and avoid any potential data loss.
+            </p>
+
+            <div style="margin: 20px 0;">
+                <a th:href="${Fix_Url}" style="background-color: #0099ff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px;">
+                    Fix your connection now
+                </a>
+            </div>
+
+            <p>
+                Need help? Reach out to us anytime at
+                <a th:href="${Help_Url}">knowHOW Request</a>.
+            </p>
+
+            <p style="margin-top: 40px;">Thanks,<br/>The KnowHow Team</p>
+        </td>
+    </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/gitlab/src/main/resources/application.properties
+++ b/gitlab/src/main/resources/application.properties
@@ -56,3 +56,14 @@ togglz.console.secured=false
 #Spring boot actuator properties
 management.endpoints.web.exposure.include=health
 management.endpoint.health.show-details=never
+
+broken-connection.maximum-email-notification-count=${MAXIMUMEMAILNOTIFICATIONCOUNT:3}
+broken-connection.email-notification-frequency=${EMAILNOTIFICATIONFREQUENCY:5}
+broken-connection.email-notification-subject=Action Required: Restore Your {{Tool_Name}} Connection
+broken-connection.fix-url=/#/dashboard/Config/ConfigSettings?tab=1
+broken-connection.help-url=https://publicissapient.atlassian.net/servicedesk/customer/portal/7/group/38/create/101
+broken-connection.kafka-mail-topic=mail-topic
+broken-connection.ui-host=localhost,127.0.0.1,ui,customapi
+broken-connection.notification-switch=true
+broken-connection.mail-without-kafka=true
+broken-connection.mail-template.Broken_Connection=Broken_Connection_Notification_Template

--- a/gitlab/src/main/resources/templates/Broken_Connection_Notification_Template.html
+++ b/gitlab/src/main/resources/templates/Broken_Connection_Notification_Template.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Broken Connection Alert</title>
+    <link href="http://fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css" />
+</head>
+
+<body style="font-family: 'Roboto', sans-serif; font-size: 16px; line-height: 24px; background-color: #f0f0f0; margin: 0;">
+<table cellpadding="0" cellspacing="0" style="width: 800px; margin: 20px auto; background-color: #ffffff;">
+    <tbody>
+    <tr>
+        <td style="padding: 30px; text-align: center;">
+            <div style="font-size: 42px;">
+                kn<span style="color: #FE414D;">o</span>w<span style="font-weight: 900;">HOW</span>
+            </div>
+            <hr style="border-top: 1px solid #0099ff;" />
+        </td>
+    </tr>
+    <tr>
+        <td style="padding: 25px;">
+            <p>Hi <strong th:text="${User_Name}"></strong>,</p>
+
+            <p>
+                We’ve detected that your <strong th:text="${Tool_Name}"></strong> connection is currently
+                <span style="color: #FE414D;">broken</span> — this is usually due to an expired token or authentication issue.
+                As a result, data fetching and syncing might be disrupted, and in some cases, historical data could be lost.
+            </p>
+
+            <p>
+                Please update your credentials promptly to ensure smooth data flow and avoid any potential data loss.
+            </p>
+
+            <div style="margin: 20px 0;">
+                <a th:href="${Fix_Url}" style="background-color: #0099ff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px;">
+                    Fix your connection now
+                </a>
+            </div>
+
+            <p>
+                Need help? Reach out to us anytime at
+                <a th:href="${Help_Url}">knowHOW Request</a>.
+            </p>
+
+            <p style="margin-top: 40px;">Thanks,<br/>The KnowHow Team</p>
+        </td>
+    </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/jenkins/src/main/resources/application.properties
+++ b/jenkins/src/main/resources/application.properties
@@ -53,3 +53,14 @@ togglz.console.secured=false
 #Spring boot actuator properties
 management.endpoints.web.exposure.include=health
 management.endpoint.health.show-details=never
+
+broken-connection.maximum-email-notification-count=${MAXIMUMEMAILNOTIFICATIONCOUNT:3}
+broken-connection.email-notification-frequency=${EMAILNOTIFICATIONFREQUENCY:5}
+broken-connection.email-notification-subject=Action Required: Restore Your {{Tool_Name}} Connection
+broken-connection.fix-url=/#/dashboard/Config/ConfigSettings?tab=1
+broken-connection.help-url=https://publicissapient.atlassian.net/servicedesk/customer/portal/7/group/38/create/101
+broken-connection.kafka-mail-topic=mail-topic
+broken-connection.ui-host=localhost,127.0.0.1,ui,customapi
+broken-connection.notification-switch=true
+broken-connection.mail-without-kafka=true
+broken-connection.mail-template.Broken_Connection=Broken_Connection_Notification_Template

--- a/jenkins/src/main/resources/templates/Broken_Connection_Notification_Template.html
+++ b/jenkins/src/main/resources/templates/Broken_Connection_Notification_Template.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Broken Connection Alert</title>
+    <link href="http://fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css" />
+</head>
+
+<body style="font-family: 'Roboto', sans-serif; font-size: 16px; line-height: 24px; background-color: #f0f0f0; margin: 0;">
+<table cellpadding="0" cellspacing="0" style="width: 800px; margin: 20px auto; background-color: #ffffff;">
+    <tbody>
+    <tr>
+        <td style="padding: 30px; text-align: center;">
+            <div style="font-size: 42px;">
+                kn<span style="color: #FE414D;">o</span>w<span style="font-weight: 900;">HOW</span>
+            </div>
+            <hr style="border-top: 1px solid #0099ff;" />
+        </td>
+    </tr>
+    <tr>
+        <td style="padding: 25px;">
+            <p>Hi <strong th:text="${User_Name}"></strong>,</p>
+
+            <p>
+                We’ve detected that your <strong th:text="${Tool_Name}"></strong> connection is currently
+                <span style="color: #FE414D;">broken</span> — this is usually due to an expired token or authentication issue.
+                As a result, data fetching and syncing might be disrupted, and in some cases, historical data could be lost.
+            </p>
+
+            <p>
+                Please update your credentials promptly to ensure smooth data flow and avoid any potential data loss.
+            </p>
+
+            <div style="margin: 20px 0;">
+                <a th:href="${Fix_Url}" style="background-color: #0099ff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px;">
+                    Fix your connection now
+                </a>
+            </div>
+
+            <p>
+                Need help? Reach out to us anytime at
+                <a th:href="${Help_Url}">knowHOW Request</a>.
+            </p>
+
+            <p style="margin-top: 40px;">Thanks,<br/>The KnowHow Team</p>
+        </td>
+    </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/jira-zephyr-scale/src/main/resources/application.properties
+++ b/jira-zephyr-scale/src/main/resources/application.properties
@@ -49,3 +49,14 @@ aesEncryptionKey=
 #Spring boot actuator properties
 management.endpoints.web.exposure.include=health
 management.endpoint.health.show-details=never
+
+broken-connection.maximum-email-notification-count=${MAXIMUMEMAILNOTIFICATIONCOUNT:3}
+broken-connection.email-notification-frequency=${EMAILNOTIFICATIONFREQUENCY:5}
+broken-connection.email-notification-subject=Action Required: Restore Your {{Tool_Name}} Connection
+broken-connection.fix-url=/#/dashboard/Config/ConfigSettings?tab=1
+broken-connection.help-url=https://publicissapient.atlassian.net/servicedesk/customer/portal/7/group/38/create/101
+broken-connection.kafka-mail-topic=mail-topic
+broken-connection.ui-host=localhost,127.0.0.1,ui,customapi
+broken-connection.notification-switch=true
+broken-connection.mail-without-kafka=true
+broken-connection.mail-template.Broken_Connection=Broken_Connection_Notification_Template

--- a/jira-zephyr-scale/src/main/resources/templates/Broken_Connection_Notification_Template.html
+++ b/jira-zephyr-scale/src/main/resources/templates/Broken_Connection_Notification_Template.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Broken Connection Alert</title>
+    <link href="http://fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css" />
+</head>
+
+<body style="font-family: 'Roboto', sans-serif; font-size: 16px; line-height: 24px; background-color: #f0f0f0; margin: 0;">
+<table cellpadding="0" cellspacing="0" style="width: 800px; margin: 20px auto; background-color: #ffffff;">
+    <tbody>
+    <tr>
+        <td style="padding: 30px; text-align: center;">
+            <div style="font-size: 42px;">
+                kn<span style="color: #FE414D;">o</span>w<span style="font-weight: 900;">HOW</span>
+            </div>
+            <hr style="border-top: 1px solid #0099ff;" />
+        </td>
+    </tr>
+    <tr>
+        <td style="padding: 25px;">
+            <p>Hi <strong th:text="${User_Name}"></strong>,</p>
+
+            <p>
+                We’ve detected that your <strong th:text="${Tool_Name}"></strong> connection is currently
+                <span style="color: #FE414D;">broken</span> — this is usually due to an expired token or authentication issue.
+                As a result, data fetching and syncing might be disrupted, and in some cases, historical data could be lost.
+            </p>
+
+            <p>
+                Please update your credentials promptly to ensure smooth data flow and avoid any potential data loss.
+            </p>
+
+            <div style="margin: 20px 0;">
+                <a th:href="${Fix_Url}" style="background-color: #0099ff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px;">
+                    Fix your connection now
+                </a>
+            </div>
+
+            <p>
+                Need help? Reach out to us anytime at
+                <a th:href="${Help_Url}">knowHOW Request</a>.
+            </p>
+
+            <p style="margin-top: 40px;">Thanks,<br/>The KnowHow Team</p>
+        </td>
+    </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/jira/src/main/resources/application.properties
+++ b/jira/src/main/resources/application.properties
@@ -135,3 +135,14 @@ togglz.console.secured=false
 #Spring boot actuator properties
 management.endpoints.web.exposure.include=health
 management.endpoint.health.show-details=never
+
+broken-connection.maximum-email-notification-count=${MAXIMUMEMAILNOTIFICATIONCOUNT:3}
+broken-connection.email-notification-frequency=${EMAILNOTIFICATIONFREQUENCY:5}
+broken-connection.email-notification-subject=Action Required: Restore Your {{Tool_Name}} Connection
+broken-connection.fix-url=/#/dashboard/Config/ConfigSettings?tab=1
+broken-connection.help-url=https://publicissapient.atlassian.net/servicedesk/customer/portal/7/group/38/create/101
+broken-connection.kafka-mail-topic=mail-topic
+broken-connection.ui-host=localhost,127.0.0.1,ui,customapi
+broken-connection.notification-switch=true
+broken-connection.mail-without-kafka=true
+broken-connection.mail-template.Broken_Connection=Broken_Connection_Notification_Template

--- a/jira/src/main/resources/templates/Broken_Connection_Notification_Template.html
+++ b/jira/src/main/resources/templates/Broken_Connection_Notification_Template.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Broken Connection Alert</title>
+    <link href="http://fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css" />
+</head>
+
+<body style="font-family: 'Roboto', sans-serif; font-size: 16px; line-height: 24px; background-color: #f0f0f0; margin: 0;">
+<table cellpadding="0" cellspacing="0" style="width: 800px; margin: 20px auto; background-color: #ffffff;">
+    <tbody>
+    <tr>
+        <td style="padding: 30px; text-align: center;">
+            <div style="font-size: 42px;">
+                kn<span style="color: #FE414D;">o</span>w<span style="font-weight: 900;">HOW</span>
+            </div>
+            <hr style="border-top: 1px solid #0099ff;" />
+        </td>
+    </tr>
+    <tr>
+        <td style="padding: 25px;">
+            <p>Hi <strong th:text="${User_Name}"></strong>,</p>
+
+            <p>
+                We’ve detected that your <strong th:text="${Tool_Name}"></strong> connection is currently
+                <span style="color: #FE414D;">broken</span> — this is usually due to an expired token or authentication issue.
+                As a result, data fetching and syncing might be disrupted, and in some cases, historical data could be lost.
+            </p>
+
+            <p>
+                Please update your credentials promptly to ensure smooth data flow and avoid any potential data loss.
+            </p>
+
+            <div style="margin: 20px 0;">
+                <a th:href="${Fix_Url}" style="background-color: #0099ff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px;">
+                    Fix your connection now
+                </a>
+            </div>
+
+            <p>
+                Need help? Reach out to us anytime at
+                <a th:href="${Help_Url}">knowHOW Request</a>.
+            </p>
+
+            <p style="margin-top: 40px;">Thanks,<br/>The KnowHow Team</p>
+        </td>
+    </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/rally/src/main/resources/application.properties
+++ b/rally/src/main/resources/application.properties
@@ -123,3 +123,14 @@ rally.userstory.baseurl=https://rally1.rallydev.com/#/detail/userstory/
 #Spring boot actuator properties
 management.endpoints.web.exposure.include=health
 management.endpoint.health.show-details=never
+
+broken-connection.maximum-email-notification-count=${MAXIMUMEMAILNOTIFICATIONCOUNT:3}
+broken-connection.email-notification-frequency=${EMAILNOTIFICATIONFREQUENCY:5}
+broken-connection.email-notification-subject=Action Required: Restore Your {{Tool_Name}} Connection
+broken-connection.fix-url=/#/dashboard/Config/ConfigSettings?tab=1
+broken-connection.help-url=https://publicissapient.atlassian.net/servicedesk/customer/portal/7/group/38/create/101
+broken-connection.kafka-mail-topic=mail-topic
+broken-connection.ui-host=localhost,127.0.0.1,ui,customapi
+broken-connection.notification-switch=true
+broken-connection.mail-without-kafka=true
+broken-connection.mail-template.Broken_Connection=Broken_Connection_Notification_Template

--- a/rally/src/main/resources/templates/Broken_Connection_Notification_Template.html
+++ b/rally/src/main/resources/templates/Broken_Connection_Notification_Template.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Broken Connection Alert</title>
+    <link href="http://fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css" />
+</head>
+
+<body style="font-family: 'Roboto', sans-serif; font-size: 16px; line-height: 24px; background-color: #f0f0f0; margin: 0;">
+<table cellpadding="0" cellspacing="0" style="width: 800px; margin: 20px auto; background-color: #ffffff;">
+    <tbody>
+    <tr>
+        <td style="padding: 30px; text-align: center;">
+            <div style="font-size: 42px;">
+                kn<span style="color: #FE414D;">o</span>w<span style="font-weight: 900;">HOW</span>
+            </div>
+            <hr style="border-top: 1px solid #0099ff;" />
+        </td>
+    </tr>
+    <tr>
+        <td style="padding: 25px;">
+            <p>Hi <strong th:text="${User_Name}"></strong>,</p>
+
+            <p>
+                We’ve detected that your <strong th:text="${Tool_Name}"></strong> connection is currently
+                <span style="color: #FE414D;">broken</span> — this is usually due to an expired token or authentication issue.
+                As a result, data fetching and syncing might be disrupted, and in some cases, historical data could be lost.
+            </p>
+
+            <p>
+                Please update your credentials promptly to ensure smooth data flow and avoid any potential data loss.
+            </p>
+
+            <div style="margin: 20px 0;">
+                <a th:href="${Fix_Url}" style="background-color: #0099ff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px;">
+                    Fix your connection now
+                </a>
+            </div>
+
+            <p>
+                Need help? Reach out to us anytime at
+                <a th:href="${Help_Url}">knowHOW Request</a>.
+            </p>
+
+            <p style="margin-top: 40px;">Thanks,<br/>The KnowHow Team</p>
+        </td>
+    </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/sonar/src/main/resources/application.properties
+++ b/sonar/src/main/resources/application.properties
@@ -55,3 +55,15 @@ togglz.console.secured=false
 #Spring boot actuator properties
 management.endpoints.web.exposure.include=health
 management.endpoint.health.show-details=never
+
+
+broken-connection.maximum-email-notification-count=${MAXIMUMEMAILNOTIFICATIONCOUNT:3}
+broken-connection.email-notification-frequency=${EMAILNOTIFICATIONFREQUENCY:5}
+broken-connection.email-notification-subject=Action Required: Restore Your {{Tool_Name}} Connection
+broken-connection.fix-url=/#/dashboard/Config/ConfigSettings?tab=1
+broken-connection.help-url=https://publicissapient.atlassian.net/servicedesk/customer/portal/7/group/38/create/101
+broken-connection.kafka-mail-topic=mail-topic
+broken-connection.ui-host=localhost,127.0.0.1,ui,customapi
+broken-connection.notification-switch=true
+broken-connection.mail-without-kafka=true
+broken-connection.mail-template.Broken_Connection=Broken_Connection_Notification_Template

--- a/sonar/src/main/resources/templates/Broken_Connection_Notification_Template.html
+++ b/sonar/src/main/resources/templates/Broken_Connection_Notification_Template.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Broken Connection Alert</title>
+    <link href="http://fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css" />
+</head>
+
+<body style="font-family: 'Roboto', sans-serif; font-size: 16px; line-height: 24px; background-color: #f0f0f0; margin: 0;">
+<table cellpadding="0" cellspacing="0" style="width: 800px; margin: 20px auto; background-color: #ffffff;">
+    <tbody>
+    <tr>
+        <td style="padding: 30px; text-align: center;">
+            <div style="font-size: 42px;">
+                kn<span style="color: #FE414D;">o</span>w<span style="font-weight: 900;">HOW</span>
+            </div>
+            <hr style="border-top: 1px solid #0099ff;" />
+        </td>
+    </tr>
+    <tr>
+        <td style="padding: 25px;">
+            <p>Hi <strong th:text="${User_Name}"></strong>,</p>
+
+            <p>
+                We’ve detected that your <strong th:text="${Tool_Name}"></strong> connection is currently
+                <span style="color: #FE414D;">broken</span> — this is usually due to an expired token or authentication issue.
+                As a result, data fetching and syncing might be disrupted, and in some cases, historical data could be lost.
+            </p>
+
+            <p>
+                Please update your credentials promptly to ensure smooth data flow and avoid any potential data loss.
+            </p>
+
+            <div style="margin: 20px 0;">
+                <a th:href="${Fix_Url}" style="background-color: #0099ff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px;">
+                    Fix your connection now
+                </a>
+            </div>
+
+            <p>
+                Need help? Reach out to us anytime at
+                <a th:href="${Help_Url}">knowHOW Request</a>.
+            </p>
+
+            <p style="margin-top: 40px;">Thanks,<br/>The KnowHow Team</p>
+        </td>
+    </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/teamcity/src/main/resources/application.properties
+++ b/teamcity/src/main/resources/application.properties
@@ -55,3 +55,14 @@ togglz.console.secured=false
 #Spring boot actuator properties
 management.endpoints.web.exposure.include=health
 management.endpoint.health.show-details=never
+
+broken-connection.maximum-email-notification-count=${MAXIMUMEMAILNOTIFICATIONCOUNT:3}
+broken-connection.email-notification-frequency=${EMAILNOTIFICATIONFREQUENCY:5}
+broken-connection.email-notification-subject=Action Required: Restore Your {{Tool_Name}} Connection
+broken-connection.fix-url=/#/dashboard/Config/ConfigSettings?tab=1
+broken-connection.help-url=https://publicissapient.atlassian.net/servicedesk/customer/portal/7/group/38/create/101
+broken-connection.kafka-mail-topic=mail-topic
+broken-connection.ui-host=localhost,127.0.0.1,ui,customapi
+broken-connection.notification-switch=true
+broken-connection.mail-without-kafka=true
+broken-connection.mail-template.Broken_Connection=Broken_Connection_Notification_Template

--- a/teamcity/src/main/resources/templates/Broken_Connection_Notification_Template.html
+++ b/teamcity/src/main/resources/templates/Broken_Connection_Notification_Template.html
@@ -1,0 +1,54 @@
+<!doctype html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport"
+          content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Broken Connection Alert</title>
+    <link href="http://fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css" />
+</head>
+
+<body style="font-family: 'Roboto', sans-serif; font-size: 16px; line-height: 24px; background-color: #f0f0f0; margin: 0;">
+<table cellpadding="0" cellspacing="0" style="width: 800px; margin: 20px auto; background-color: #ffffff;">
+    <tbody>
+    <tr>
+        <td style="padding: 30px; text-align: center;">
+            <div style="font-size: 42px;">
+                kn<span style="color: #FE414D;">o</span>w<span style="font-weight: 900;">HOW</span>
+            </div>
+            <hr style="border-top: 1px solid #0099ff;" />
+        </td>
+    </tr>
+    <tr>
+        <td style="padding: 25px;">
+            <p>Hi <strong th:text="${User_Name}"></strong>,</p>
+
+            <p>
+                We’ve detected that your <strong th:text="${Tool_Name}"></strong> connection is currently
+                <span style="color: #FE414D;">broken</span> — this is usually due to an expired token or authentication issue.
+                As a result, data fetching and syncing might be disrupted, and in some cases, historical data could be lost.
+            </p>
+
+            <p>
+                Please update your credentials promptly to ensure smooth data flow and avoid any potential data loss.
+            </p>
+
+            <div style="margin: 20px 0;">
+                <a th:href="${Fix_Url}" style="background-color: #0099ff; color: white; padding: 10px 20px; text-decoration: none; border-radius: 4px;">
+                    Fix your connection now
+                </a>
+            </div>
+
+            <p>
+                Need help? Reach out to us anytime at
+                <a th:href="${Help_Url}">knowHOW Request</a>.
+            </p>
+
+            <p style="margin-top: 40px;">Thanks,<br/>The KnowHow Team</p>
+        </td>
+    </tr>
+    </tbody>
+</table>
+</body>
+</html>


### PR DESCRIPTION
Review Note:

Processor tools such as Jira, GitHub, GitLab, etc., rely on common library code to handle broken connection updates. I have implemented a fix that allows each processor to continue using the shared logic while supplying their own application-specific properties. This provides flexibility to:

Disable email notifications for individual processors if needed

Enable independent email handling per processor

This approach avoids anti-patterns by keeping shared logic centralized while allowing environment-specific configuration at the application level.