### PR TITLE
Fix: retain sprints with all issues punted in the filter dropdown

### DIFF
--- a/jira/src/main/java/com/publicissapient/kpidashboard/jira/service/ProjectHierarchySyncServiceImpl.java
+++ b/jira/src/main/java/com/publicissapient/kpidashboard/jira/service/ProjectHierarchySyncServiceImpl.java
@@ -26,9 +26,8 @@ import org.springframework.stereotype.Service;
 
 import com.publicissapient.kpidashboard.common.constant.CommonConstant;
 import com.publicissapient.kpidashboard.common.model.application.ProjectHierarchy;
-import com.publicissapient.kpidashboard.common.model.jira.JiraIssue;
+import com.publicissapient.kpidashboard.common.model.jira.SprintDetails;
 import com.publicissapient.kpidashboard.common.repository.application.ProjectHierarchyRepository;
-import com.publicissapient.kpidashboard.common.repository.jira.JiraIssueRepository;
 import com.publicissapient.kpidashboard.common.repository.jira.SprintRepository;
 
 import lombok.extern.slf4j.Slf4j;
@@ -42,32 +41,33 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ProjectHierarchySyncServiceImpl implements ProjectHierarchySyncService {
 
-	@Autowired private JiraIssueRepository jiraIssueRepository;
-
 	@Autowired private ProjectHierarchyRepository projectHierarchyRepository;
 
 	@Autowired private SprintRepository sprintRepository;
 
 	/**
-	 * Synchronizes the hierarchy of Scrum sprints by comparing the sprint IDs in Jira issues with
+	 * Synchronizes the hierarchy of Scrum sprints by comparing the sprint IDs in sprint_details with
 	 * those in the account hierarchy and deleting non-matching entries.
+	 *
+	 * <p>Uses sprint_details as the source of truth rather than jira_issues.sprintID, so that sprints
+	 * where all issues were punted to other sprints are not incorrectly removed from the hierarchy.
 	 *
 	 * @param basicProjectConfigId the ID of the basic project configuration
 	 */
 	@Override
 	public void syncScrumSprintHierarchy(ObjectId basicProjectConfigId) {
-		List<String> distinctSprintIDs =
-				jiraIssueRepository
-						.findDistinctSprintIDsByBasicProjectConfigId(String.valueOf(basicProjectConfigId))
-						.stream()
-						.map(JiraIssue::getSprintID)
+		List<String> sprintIDsInSprintDetails =
+				sprintRepository.findByBasicProjectConfigId(basicProjectConfigId).stream()
+						.map(SprintDetails::getSprintID)
 						.toList();
 
-		// Find nodeIds that are in projectHierarchy but not in jira issue sprintIDs
+		// Find nodeIds that are in projectHierarchy but not in sprint_details — truly orphaned sprints
 		List<String> nonMatchingNodeIds =
 				projectHierarchyRepository
 						.findNodeIdsByBasicProjectConfigIdAndNodeIdNotIn(
-								basicProjectConfigId, distinctSprintIDs, CommonConstant.HIERARCHY_LEVEL_ID_SPRINT)
+								basicProjectConfigId,
+								sprintIDsInSprintDetails,
+								CommonConstant.HIERARCHY_LEVEL_ID_SPRINT)
 						.stream()
 						.map(ProjectHierarchy::getNodeId)
 						.toList();
@@ -77,9 +77,6 @@ public class ProjectHierarchySyncServiceImpl implements ProjectHierarchySyncServ
 					"Syncing sprint details of projectId {}. Deleting sprintID: {}",
 					basicProjectConfigId,
 					nonMatchingNodeIds);
-			sprintRepository.deleteBySprintIDInAndBasicProjectConfigId(
-					nonMatchingNodeIds, basicProjectConfigId);
-
 			deleteNonMatchingEntries(
 					basicProjectConfigId, nonMatchingNodeIds, CommonConstant.HIERARCHY_LEVEL_ID_SPRINT);
 		}

--- a/jira/src/test/java/com/publicissapient/kpidashboard/jira/service/ProjectHierarchySyncServiceImplTest.java
+++ b/jira/src/test/java/com/publicissapient/kpidashboard/jira/service/ProjectHierarchySyncServiceImplTest.java
@@ -33,12 +33,10 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import com.publicissapient.kpidashboard.common.constant.CommonConstant;
 import com.publicissapient.kpidashboard.common.model.application.ProjectHierarchy;
-import com.publicissapient.kpidashboard.common.model.jira.JiraIssue;
 import com.publicissapient.kpidashboard.common.model.jira.KanbanJiraIssue;
+import com.publicissapient.kpidashboard.common.model.jira.SprintDetails;
 import com.publicissapient.kpidashboard.common.repository.application.ProjectHierarchyRepository;
-import com.publicissapient.kpidashboard.common.repository.jira.JiraIssueRepository;
 import com.publicissapient.kpidashboard.common.repository.jira.SprintRepository;
-import com.publicissapient.kpidashboard.jira.dataFactories.JiraIssueDataFactory;
 import com.publicissapient.kpidashboard.jira.dataFactories.KanbanJiraIssueDataFactory;
 import com.publicissapient.kpidashboard.jira.dataFactories.ProjectHierarchiesDataFactory;
 
@@ -47,14 +45,12 @@ public class ProjectHierarchySyncServiceImplTest {
 
 	@InjectMocks private ProjectHierarchySyncServiceImpl projectHierarchySyncServiceImpl;
 
-	@Mock private JiraIssueRepository jiraIssueRepository;
-
 	@Mock ProjectHierarchyRepository accountHierarchyRepository;
 
 	@Mock SprintRepository sprintRepository;
 
 	List<ProjectHierarchy> accountHierarchyList;
-	List<JiraIssue> jiraIssueList;
+	List<SprintDetails> sprintDetailsList;
 	List<KanbanJiraIssue> kanbanJiraIssueList;
 	List<ProjectHierarchy> fetchedReleasedHierarchy;
 
@@ -63,9 +59,11 @@ public class ProjectHierarchySyncServiceImplTest {
 		ProjectHierarchiesDataFactory accountHierarchiesDataFactory =
 				ProjectHierarchiesDataFactory.newInstance("/json/default/project_hierarchy.json");
 		accountHierarchyList = accountHierarchiesDataFactory.getAccountHierarchies();
-		JiraIssueDataFactory jiraIssueDataFactory =
-				JiraIssueDataFactory.newInstance("/json/default/jira_issues.json");
-		jiraIssueList = jiraIssueDataFactory.getJiraIssues();
+		SprintDetails sprint1 = new SprintDetails();
+		sprint1.setSprintID("Sprint1");
+		SprintDetails sprint2 = new SprintDetails();
+		sprint2.setSprintID("Sprint2");
+		sprintDetailsList = List.of(sprint1, sprint2);
 		KanbanJiraIssueDataFactory kanbanJiraIssueDataFactory =
 				KanbanJiraIssueDataFactory.newInstance("/json/default/kanban_jira_issue.json");
 		kanbanJiraIssueList = kanbanJiraIssueDataFactory.getKanbanJiraIssues();
@@ -79,14 +77,9 @@ public class ProjectHierarchySyncServiceImplTest {
 	@Test
 	public void syncScrumSprintHierarchyNoSprintsToDeleteFalseHit() {
 		ObjectId projectId = new ObjectId();
-		List<String> distinctSprintIDs = List.of("Sprint1", "Sprint2");
 		List<String> nonMatchingNodeIds = List.of();
 
-		when(jiraIssueRepository.findDistinctSprintIDsByBasicProjectConfigId(String.valueOf(projectId)))
-				.thenReturn(jiraIssueList);
-		// when(accountHierarchyRepository.findNodeIdsByBasicProjectConfigIdAndNodeIdNotIn(projectId,
-		// distinctSprintIDs,
-		// CommonConstant.HIERARCHY_LEVEL_ID_SPRINT)).thenReturn(accountHierarchyList);
+		when(sprintRepository.findByBasicProjectConfigId(projectId)).thenReturn(sprintDetailsList);
 
 		projectHierarchySyncServiceImpl.syncScrumSprintHierarchy(projectId);
 
@@ -170,11 +163,10 @@ public class ProjectHierarchySyncServiceImplTest {
 		ObjectId projectId = new ObjectId();
 		List<String> nonMatchingNodeIds = List.of();
 
-		when(jiraIssueRepository.findDistinctSprintIDsByBasicProjectConfigId(String.valueOf(projectId)))
-				.thenReturn(jiraIssueList);
+		when(sprintRepository.findByBasicProjectConfigId(projectId)).thenReturn(sprintDetailsList);
 		when(accountHierarchyRepository.findNodeIdsByBasicProjectConfigIdAndNodeIdNotIn(
 						projectId,
-						jiraIssueList.stream().map(JiraIssue::getSprintID).toList(),
+						sprintDetailsList.stream().map(SprintDetails::getSprintID).toList(),
 						CommonConstant.HIERARCHY_LEVEL_ID_SPRINT))
 				.thenReturn(accountHierarchyList);
 


### PR DESCRIPTION
syncScrumSprintHierarchy used jira_issues.sprintID as the source of truth, causing sprints where all issues were punted to be deleted from project_hierarchy. Changed to use sprint_details instead, which reflects all sprints fetched from Jira regardless of issue assignment.